### PR TITLE
feat: add organization-wide pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -20,5 +20,5 @@
 - [ ] PR title ends with a JIRA issue ID  <!-- `fix: signup error [DIA-000]` -->
 - [ ] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
 - [ ] [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests) is opened for WIP changes <!-- If required. -->
-- [ ] PR reviewers are assigned <!-- It's better to add whole teams rather than specific people; i.e.: `@dialoguemd/maestro` or `@dialoguemd/s-team`. -->
+- [ ] PR review requested from groups not individuals <!-- It's better to add whole teams rather than specific people; i.e.: `@dialoguemd/maestro` or `@dialoguemd/s-team`. -->
 - [ ] PR link is posted to the corresponding Slack channel <!-- This will quickly draw attention to your PR. -->


### PR DESCRIPTION
## Description
Add organization-wide pull request tempate that is supposed to be propagated to all other repositories.

## Checklist

- [x] PR branch has a descriptive name that starts with `fix/`, `feat/` or `chore/` <!-- `fix/signup-issue`, `feat/email-verification` or `chore/update-ci-script` -->
- [x] PR title follows [Commit Convention](https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0) <!-- `feat(lang): add German language` -->
- [x] All PR sections above are populated <!-- Remove sections if they do not apply -->
- [x] [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests) is opened for WIP changes <!-- If required -->
- [x] PR review requested from groups not individuals <!-- It's better to add whole teams rather than specific people; i.e.: `@dialoguemd/maestro` or `@dialoguemd/s-team`. -->
- [x] PR link is posted to the corresponding Slack channel <!-- This will quickly draw attention to your PR -->