### PR TITLE
fix: make PR template more readable

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 - [ ] Relevant labels set 
 - [ ] Empty sections removed
 - [ ] [Draft PR] for WIP
-- [ ] Requested and notified to a team <!-- @dialoguemd/nexus -->
+- [ ] Requested and notified to a team
 
 
 <!-- don't remove -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,29 @@
 ## Description
-<!-- Short summary of your changes. -->
-<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
-<!-- You can also leave notes for code reviewers here. -->
+
+<!-- Short summary to give context to reviewers-->
+<!-- screenshots/gifs if needed 🎥 -->
 
 ## Related JIRA issues
-<!-- Pull requests should be related to open JIRA issues. -->
-<!-- Please put all related JIRA issue IDs in square brackets here: -->
-<!-- * [DIA-123] -->
-<!-- * [SOL-456] -->
+
+* [DIA-XXXXX]
+
 
 ## Related changes
-<!-- What other PRs does this PR depend on? -->
-<!-- Please put references to other PRs here: -->
-<!-- * dialoguemd/{repository}#{pr-number}  -->
+
+<!-- * #123 -->
+<!-- * dialoguemd/scribe#1234  -->
 
 ## Checklist
 
-- [ ] PR title follows [Commit Convention](https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0) <!-- `feat(lang): add German language` -->
-- [ ] PR title ends with a JIRA issue ID  <!-- `fix: signup error [DIA-000]` -->
-- [ ] All relevant labels are added <!-- Labels help with PR classification -->
-- [ ] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
-- [ ] [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests) is opened for WIP changes <!-- If required. -->
-- [ ] PR review requested from groups not individuals <!-- It's better to add whole teams rather than specific people; i.e.: `@dialoguemd/maestro` or `@dialoguemd/s-team`. -->
-- [ ] PR link is posted to the corresponding Slack channel <!-- This will quickly draw attention to your PR. -->
+- [ ] PR follows [Commit Convention] and [Code Review guidelines] <!-- `feat(lang): add German language` -->
+- [ ] PR title ends with a JIRA issue ID  <!-- `fix: signup error - DIA-12345` -->
+- [ ] All relevant labels are added <!-- Helps with classification -->
+- [ ] All relevant PR sections are populated, irrelevant ones are removed
+- [ ] [Draft PR] is opened for WIP
+- [ ] PR review requested from groups <!-- `@dialoguemd/maestro` or `@dialoguemd/s-team`. -->
+- [ ] PR posted to the corresponding Slack channel
+
+
+[Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
+[Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9
+[Draft PR]: https://github.blog/2019-02-14-introducing-draft-pull-requests

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 * [DIA-XXXXX]
 
-## Related PR
+## Related PRs
 
 <!-- * #123 -->
 <!-- * dialoguemd/scribe#1234  -->
@@ -17,7 +17,7 @@
 - [ ] Relevant labels set 
 - [ ] Empty sections removed
 - [ ] [Draft PR] for WIP
-- [ ] Requested and notified to a team
+- [ ] Requested from and notified to a team
 
 
 <!-- don't remove -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,10 @@
 ## Description
 
-<!-- Short summary for reviewers-->
-<!-- screenshots/gifs if needed 🎥 -->
+<!-- Short summary for reviewers -->
 
 ## Related JIRA issues
 
 * [DIA-XXXXX]
-
 
 ## Related PR
 
@@ -15,12 +13,14 @@
 
 ## Checklist
 
-- [ ] Follows [Commit Convention] and [Code Review guidelines] <!-- `feat(lang): add German language` -->
-- [ ] Title suffixed by issue ID  <!-- fix: signup error - DIA-12345 -->
-- [ ] Relevant labels set
+- [ ] Follows [Commit Convention] and [Code Review guidelines] <!-- feat(lang): add German language - DIA-12345 -->
+- [ ] Relevant labels set 
+- [ ] Empty sections removed
 - [ ] [Draft PR] for WIP
-- [ ] Requested and notified to team <!-- `@dialoguemd/maestro` or `@dialoguemd/s-team`. -->
+- [ ] Requested and notified to a team <!-- @dialoguemd/nexus -->
 
+
+<!-- don't remove -->
 [Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
 [Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9
 [Draft PR]: https://github.blog/2019-02-14-introducing-draft-pull-requests

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Description
 
-<!-- Short summary to give context to reviewers-->
+<!-- Short summary for reviewers-->
 <!-- screenshots/gifs if needed 🎥 -->
 
 ## Related JIRA issues
@@ -8,21 +8,18 @@
 * [DIA-XXXXX]
 
 
-## Related changes
+## Related PR
 
 <!-- * #123 -->
 <!-- * dialoguemd/scribe#1234  -->
 
 ## Checklist
 
-- [ ] PR follows [Commit Convention] and [Code Review guidelines] <!-- `feat(lang): add German language` -->
-- [ ] PR title ends with a JIRA issue ID  <!-- `fix: signup error - DIA-12345` -->
-- [ ] All relevant labels are added <!-- Helps with classification -->
-- [ ] All relevant PR sections are populated, irrelevant ones are removed
-- [ ] [Draft PR] is opened for WIP
-- [ ] PR review requested from groups <!-- `@dialoguemd/maestro` or `@dialoguemd/s-team`. -->
-- [ ] PR posted to the corresponding Slack channel
-
+- [ ] Follows [Commit Convention] and [Code Review guidelines] <!-- `feat(lang): add German language` -->
+- [ ] Title suffixed by issue ID  <!-- fix: signup error - DIA-12345 -->
+- [ ] Relevant labels set
+- [ ] [Draft PR] for WIP
+- [ ] Requested and notified to team <!-- `@dialoguemd/maestro` or `@dialoguemd/s-team`. -->
 
 [Commit Convention]: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0
 [Code Review guidelines]: https://www.notion.so/godialogue/Code-Review-c5f3fcd185ca49aca73ade497c398fe9


### PR DESCRIPTION
## Description

I felt like PR template could be more readable

## Checklist

- [x] PR title follows [Commit Convention](https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0) <!-- `feat(lang): add German language` -->
- [ ] PR title ends with a JIRA issue ID  <!-- `fix: signup error [DIA-000]` -->
- [ ] All relevant labels are added <!-- Labels help with PR classification -->
- [ ] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
- [ ] [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests) is opened for WIP changes <!-- If required. -->
- [x] PR review requested from groups not individuals <!-- It's better to add whole teams rather than specific people; i.e.: `@dialoguemd/maestro` or `@dialoguemd/s-team`. -->
- [x] PR link is posted to the corresponding Slack channel <!-- This will quickly draw attention to your PR. -->
