### PR TITLE
fix: update github semantic app [DIA-76673] 

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,15 @@
+# https://github.com/Ezard/semantic-prs
+# Always validate the PR title, and ignore the commits
+
+# Reference Dialogue Commit Convention:
+# https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0?pvs=4
+titleOnly: true
+types:
+  - chore
+  - fix
+  - feat
+  - test
+  - docs
+  - style
+  - refactor
+  - perf

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,9 +1,17 @@
-# https://github.com/Ezard/semantic-prs
-# Always validate the PR title, and ignore the commits
+# Notes:
+#
+# - Config syntax: https://github.com/Ezard/semantic-prs
+# - If a repo has their own `semantic.yml` config file, that file will be used instead of this one.
+#   - See https://github.com/Ezard/semantic-prs/issues/227 for more info.
 
-# Reference Dialogue Commit Convention:
-# https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0?pvs=4
+# Validate the PR title, and ignore all commit messages
 titleOnly: true
+
+# Provides a custom URL for the "Details" link, which appears next to the success/failure message from the app:
+targetUrl: https://www.notion.so/godialogue/Commit-Convention-84fd9a4c149e48c998d760f1c9176df0?pvs=4
+
+# The values allowed for the "type" part of the PR title/commit message.
+# e.g. for a PR title/commit message of "feat: add some stuff", the type would be "feat"
 types:
   - chore
   - fix
@@ -12,4 +20,5 @@ types:
   - docs
   - style
   - refactor
+  - revert
   - perf


### PR DESCRIPTION
>[!note]
> Requires [Semantic PRs app](https://github.com/marketplace/semantic-prs) to be installed on repositories that release packages.

## Problem

A recent commit with a non-conventional title (`Feat:` instead of `feat:`) was merged into the `dialogue.events` repository. This caused the release job to fail as the package version was not incremented.

## Solution

Update the existing [Github App - "Semantic Pull Requests"](https://github.com/zeke/semantic-pull-requests) that is no longer being maintained for ["Semantic PRs"](https://github.com/Ezard/semantic-prs). 

## Related

*  [DIA-76673]
*  [engage - PR if this is too broad](https://github.com/dialoguemd/engage/pull/535)

## Validation

- ❌  [Non-Semantic PR title](https://github.com/sachasmart/external-spike/pull/1)
- ✅  [Semantic PR title](https://github.com/sachasmart/external-spike/pull/2)


[DIA-76673]: https://dialoguemd.atlassian.net/browse/DIA-76673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ